### PR TITLE
Use `pkg` plugin attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,3 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
-
-# Metrics report
-/metrics.json

--- a/index.js
+++ b/index.js
@@ -2,8 +2,6 @@
 var monk    = require("monk");
 var _       = require("lodash");
 
-var version = require("./package.json").version;
-
 exports.register = function (plugin, options, done) {
 	options.url = options.url || "mongodb://localhost:27017";
 
@@ -16,6 +14,5 @@ exports.register = function (plugin, options, done) {
 };
 
 exports.register.attributes = {
-	name    : "hapi-monk",
-	version : version
+	pkg : require("./package.json")
 };

--- a/test/hapi-monk_spec.js
+++ b/test/hapi-monk_spec.js
@@ -25,18 +25,15 @@ describe("The hapi-monk plugin", function () {
 
 	describe("attributes", function () {
 		var attributes;
+		var pkg = require("../package.json");
 
 		before(function () {
 			attributes = hapiMonk.register.attributes;
 		});
 
-		it("has the correct name", function () {
-			expect(attributes.name, "wrong name").to.equal("hapi-monk");
-		});
-
-		it("has the correct version", function () {
-			var version = require("../package.json").version;
-			expect(attributes.version, "wrong version").to.equal(version);
+		it("has pkg", function () {
+			expect(attributes.pkg, "not an object").to.be.an("object");
+			expect(attributes.pkg, "not right package").to.equal(pkg);
 		});
 	});
 


### PR DESCRIPTION
This PR makes the plugin use the `pkg` property on the plugin attributes rather than separately specifying `name` and `version`.
